### PR TITLE
Feat/expose prom metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode/launch.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "useTabs": false,
+  "bracketSpacing": true
+}

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.28.1-beta.2",
+    "@lukasdeco/prom-client": "^15.1.1",
     "@openbook-dex/openbook-v2": "^0.1.9",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.90.0",
@@ -18,12 +19,14 @@
     "bs58": "^4.0.1",
     "commander": "^12.0.0",
     "inquirer": "^9.2.14",
+    "express": "^4.19.2",
     "match-discriminated-union": "^1.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/bs58": "^4.0.1",
     "@types/inquirer": "^9.0.7",
+    "@types/express": "^4.17.21",
     "@types/node": "^20.10.6",
     "bun-types": "^1.0.30"
   }

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -1,21 +1,26 @@
-import { getProposals } from './proposal-indexer';
-import { getTransactionHistory } from './transaction/history';
-import { PublicKey, SystemProgram } from '@solana/web3.js';
-import { OpenbookTwapIndexer } from './indexers/openbook-twap/openbook-twap-indexer';
-import { AutocratV0_1Indexer } from './indexers/autocrat/autocrat-v0_1-indexer';
-import { AutocratV0Indexer } from './indexers/autocrat/autocrat-v0-indexer';
-import { startTransactionWatchers } from './transaction/watcher';
-import { startIndexers } from './indexers';
-import { getTransaction } from './transaction/serializer';
-import { connection } from './connection';
+import { getProposals } from "./proposal-indexer";
+import { getTransactionHistory } from "./transaction/history";
+import { PublicKey, SystemProgram } from "@solana/web3.js";
+import { OpenbookTwapIndexer } from "./indexers/openbook-twap/openbook-twap-indexer";
+import { AutocratV0_1Indexer } from "./indexers/autocrat/autocrat-v0_1-indexer";
+import { AutocratV0Indexer } from "./indexers/autocrat/autocrat-v0-indexer";
+import { startTransactionWatchers } from "./transaction/watcher";
+import { startIndexers } from "./indexers";
+import { getTransaction } from "./transaction/serializer";
+import { connection } from "./connection";
+import { startMetricsServer } from "./metrics";
 
 //const proposals = await getProposals();
 //console.log(`got ${proposals.length} proposals`);
 //proposals.forEach(proposal => { console.log(JSON.stringify(proposal, null, 2)) });
 //const proposal = proposals[0];
 //const passTwapAcct = proposal.account.openbookTwapPassMarket;
-const prop9PassTwapAcct = new PublicKey("GpLACVBR3DMxNDfeFMKrhNnycs7ghdCwJeXSvccL5a3Z");
-const prop10PassTwapAcct = new PublicKey("EgAtJ6WXAiXEQfTL2ci8dLY2dnynLP4tsspF9u8uiiAn");
+const prop9PassTwapAcct = new PublicKey(
+  "GpLACVBR3DMxNDfeFMKrhNnycs7ghdCwJeXSvccL5a3Z"
+);
+const prop10PassTwapAcct = new PublicKey(
+  "EgAtJ6WXAiXEQfTL2ci8dLY2dnynLP4tsspF9u8uiiAn"
+);
 
 // V0 transactions (from autocrat 0.1) (metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq)
 // z3EFh3BtGMT5Y5suVYDthUFS5v8WioxdDo8HMwMbyfvieyBBN8jazJkMSXBALRfMac2RpZJXsahdNziQfvqVU8m
@@ -73,5 +78,6 @@ console.log("parsed transaction");
 print(await connection.getParsedTransaction(sig, {maxSupportedTransactionVersion: 0}));
 //*/
 
+startMetricsServer();
 startTransactionWatchers();
 //startIndexers();

--- a/packages/indexer/src/indexers/autocrat/autocrat-v0-indexer.ts
+++ b/packages/indexer/src/indexers/autocrat/autocrat-v0-indexer.ts
@@ -1,7 +1,7 @@
 import { AUTOCRAT_VERSIONS } from "@themetadao/futarchy-ts/lib/constants";
 import { IDL, AutocratV0 } from "@themetadao/futarchy-ts/lib/idl/autocrat_v0";
 import { Err, InstructionIndexer, Ok } from "../instruction-indexer";
-import logger from "../../logger";
+import { logger } from "../../logger";
 
 const AUTOCRAT_V0 = AUTOCRAT_VERSIONS[AUTOCRAT_VERSIONS.length - 1];
 

--- a/packages/indexer/src/indexers/autocrat/autocrat-v0-indexer.ts
+++ b/packages/indexer/src/indexers/autocrat/autocrat-v0-indexer.ts
@@ -1,11 +1,14 @@
 import { AUTOCRAT_VERSIONS } from "@themetadao/futarchy-ts/lib/constants";
 import { IDL, AutocratV0 } from "@themetadao/futarchy-ts/lib/idl/autocrat_v0";
 import { Err, InstructionIndexer, Ok } from "../instruction-indexer";
+import logger from "../../logger";
 
 const AUTOCRAT_V0 = AUTOCRAT_VERSIONS[AUTOCRAT_VERSIONS.length - 1];
 
 if (AUTOCRAT_V0.label !== "V0") {
-  throw new Error(`Mistook autocrat ${AUTOCRAT_V0.label} for V0`);
+  const error = new Error(`Mistook autocrat ${AUTOCRAT_V0.label} for V0`);
+  logger.error(error.message);
+  throw error;
 }
 
 export const AutocratV0Indexer: InstructionIndexer<AutocratV0> = {
@@ -14,5 +17,5 @@ export const AutocratV0Indexer: InstructionIndexer<AutocratV0> = {
   PROGRAM_IDL: AUTOCRAT_V0.idl as any,
   indexInstruction: async (dbTx, txIdx, txRes, ixIdx, ix) => {
     return Ok;
-  }
+  },
 };

--- a/packages/indexer/src/indexers/autocrat/autocrat-v0_1-indexer.ts
+++ b/packages/indexer/src/indexers/autocrat/autocrat-v0_1-indexer.ts
@@ -1,7 +1,7 @@
 import { AUTOCRAT_VERSIONS } from "@themetadao/futarchy-ts/lib/constants";
 import { IDL, AutocratV0 } from "@themetadao/futarchy-ts/lib/idl/autocrat_v0.1";
 import { InstructionIndexer, Ok } from "../instruction-indexer";
-import logger from "../../logger";
+import { logger } from "../../logger";
 
 const AUTOCRAT_V0_1 = AUTOCRAT_VERSIONS[AUTOCRAT_VERSIONS.length - 2];
 

--- a/packages/indexer/src/indexers/autocrat/autocrat-v0_1-indexer.ts
+++ b/packages/indexer/src/indexers/autocrat/autocrat-v0_1-indexer.ts
@@ -1,11 +1,14 @@
 import { AUTOCRAT_VERSIONS } from "@themetadao/futarchy-ts/lib/constants";
 import { IDL, AutocratV0 } from "@themetadao/futarchy-ts/lib/idl/autocrat_v0.1";
-import { Err, InstructionIndexer, Ok } from "../instruction-indexer";
+import { InstructionIndexer, Ok } from "../instruction-indexer";
+import logger from "../../logger";
 
 const AUTOCRAT_V0_1 = AUTOCRAT_VERSIONS[AUTOCRAT_VERSIONS.length - 2];
 
 if (AUTOCRAT_V0_1.label !== "V0.1") {
-  throw new Error(`Mistook autocrat ${AUTOCRAT_V0_1.label} for V0.1`);
+  const error = new Error(`Mistook autocrat ${AUTOCRAT_V0_1.label} for V0.1`);
+  logger.error(error.message);
+  throw error;
 }
 
 export const AutocratV0_1Indexer: InstructionIndexer<AutocratV0> = {
@@ -14,5 +17,5 @@ export const AutocratV0_1Indexer: InstructionIndexer<AutocratV0> = {
   PROGRAM_IDL: IDL,
   indexInstruction: async (dbTx, txIdx, txRes, ixIdx, ix) => {
     return Ok;
-  }
+  },
 };

--- a/packages/indexer/src/local-cache.ts
+++ b/packages/indexer/src/local-cache.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import logger from "./logger";
+import { logger } from "./logger";
 
 const CACHE_DIR = path.resolve(__dirname, "cache");
 const CACHE_LOCALLY = false; // TODO: turn off when ready to actually start indexing
@@ -26,7 +26,7 @@ export async function get(key: string[]): Promise<string[] | undefined> {
   if (!CACHE_LOCALLY) return undefined;
   const { file } = getFileAndDirPath(key);
   if (fs.existsSync(file)) {
-    console.log(`Cache hit on ${key.join("/")}`);
+    logger.log(`Cache hit on ${key.join("/")}`);
     return (await fs.promises.readFile(file)).toString().split("\n");
   }
   return undefined;

--- a/packages/indexer/src/local-cache.ts
+++ b/packages/indexer/src/local-cache.ts
@@ -1,29 +1,32 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
+import logger from "./logger";
 
-const CACHE_DIR = path.resolve(__dirname, 'cache');
+const CACHE_DIR = path.resolve(__dirname, "cache");
 const CACHE_LOCALLY = false; // TODO: turn off when ready to actually start indexing
 
 if (!fs.existsSync(CACHE_DIR)) {
   await fs.promises.mkdir(CACHE_DIR);
 }
 
-function getFileAndDirPath(key: string[]): {file: string; dir: string;} {
+function getFileAndDirPath(key: string[]): { file: string; dir: string } {
   if (key.length === 0) {
-    throw new Error("Invalid empty key");
+    const error = new Error("Invalid empty key");
+    logger.error(error.message);
+    throw error;
   }
   const keyCopy = [...key];
   const filename = keyCopy.pop()!;
-  const dir = path.resolve(CACHE_DIR, keyCopy.join('/'));
+  const dir = path.resolve(CACHE_DIR, keyCopy.join("/"));
   const file = path.resolve(dir, filename);
-  return {file, dir};
+  return { file, dir };
 }
 
 export async function get(key: string[]): Promise<string[] | undefined> {
   if (!CACHE_LOCALLY) return undefined;
   const { file } = getFileAndDirPath(key);
   if (fs.existsSync(file)) {
-    console.log(`Cache hit on ${key.join('/')}`);
+    console.log(`Cache hit on ${key.join("/")}`);
     return (await fs.promises.readFile(file)).toString().split("\n");
   }
   return undefined;
@@ -32,6 +35,6 @@ export async function get(key: string[]): Promise<string[] | undefined> {
 export async function set(key: string[], value: string[]): Promise<void> {
   if (!CACHE_LOCALLY) return;
   const { file, dir } = getFileAndDirPath(key);
-  await fs.promises.mkdir(dir, {recursive: true});
+  await fs.promises.mkdir(dir, { recursive: true });
   await fs.promises.writeFile(file, value.join("\n"));
 }

--- a/packages/indexer/src/logger.ts
+++ b/packages/indexer/src/logger.ts
@@ -34,4 +34,5 @@ export class Logger {
   }
 }
 
-export default new Logger();
+// TODO: add lint rule preventing default exports (default exports are antithetical to IDE auto refactors)
+export const logger = new Logger();

--- a/packages/indexer/src/logger.ts
+++ b/packages/indexer/src/logger.ts
@@ -1,0 +1,37 @@
+import { Counter } from "@lukasdeco/prom-client";
+export class Logger {
+  private errorCounter;
+  private warnCounter;
+
+  constructor() {
+    this.errorCounter = new Counter({
+      name: "errors",
+      help: "number of errors",
+    });
+
+    this.warnCounter = new Counter({
+      name: "warnings",
+      help: "number of warnings",
+    });
+  }
+
+  log(message: string): void {
+    console.log(message);
+  }
+
+  info(message: string): void {
+    console.info(message);
+  }
+
+  error(message: string): void {
+    console.error(message);
+    this.errorCounter.inc();
+  }
+
+  warn(message: string): void {
+    console.warn(message);
+    this.warnCounter.inc();
+  }
+}
+
+export default new Logger();

--- a/packages/indexer/src/metrics.ts
+++ b/packages/indexer/src/metrics.ts
@@ -1,14 +1,14 @@
-import Prometheus from "@lukasdeco/prom-client";
 import express from "express";
+import { Registry, collectDefaultMetrics } from "@lukasdeco/prom-client";
 
 const METRICS_PORT = 8080;
 
 export function startMetricsServer() {
-  const register = new Prometheus.Registry();
+  const register = new Registry();
   register.setDefaultLabels({
     app: "futarchy-indexer",
   });
-  Prometheus.collectDefaultMetrics({
+  collectDefaultMetrics({
     register,
     excludedMetrics: [
       "nodejs_eventloop_lag_seconds",

--- a/packages/indexer/src/metrics.ts
+++ b/packages/indexer/src/metrics.ts
@@ -1,0 +1,32 @@
+import Prometheus from "@lukasdeco/prom-client";
+import express from "express";
+
+const METRICS_PORT = 8080;
+
+export function startMetricsServer() {
+  const register = new Prometheus.Registry();
+  register.setDefaultLabels({
+    app: "futarchy-indexer",
+  });
+  Prometheus.collectDefaultMetrics({
+    register,
+    excludedMetrics: [
+      "nodejs_eventloop_lag_seconds",
+      "nodejs_heap_space_size_total_bytes",
+    ],
+  });
+
+  const app = express();
+
+  app.get("/metrics", function (_, res) {
+    res.setHeader("Content-Type", register.contentType);
+
+    register.metrics().then((data) => {
+      res.status(200).send(data);
+    });
+  });
+
+  app.listen(METRICS_PORT, () => {
+    console.log("Prometheus Metrics Servier listening on Port", METRICS_PORT);
+  });
+}

--- a/packages/indexer/src/metrics.ts
+++ b/packages/indexer/src/metrics.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { Registry, collectDefaultMetrics } from "@lukasdeco/prom-client";
+import { logger } from './logger';
 
 const METRICS_PORT = 8080;
 
@@ -18,6 +19,7 @@ export function startMetricsServer() {
 
   const app = express();
 
+  // TODO: add authz layer to all API calls
   app.get("/metrics", function (_, res) {
     res.setHeader("Content-Type", register.contentType);
 
@@ -27,6 +29,6 @@ export function startMetricsServer() {
   });
 
   app.listen(METRICS_PORT, () => {
-    console.log("Prometheus Metrics Servier listening on Port", METRICS_PORT);
+    logger.log(`Prometheus Metrics Servier listening on Port ${METRICS_PORT}`);
   });
 }

--- a/packages/indexer/src/transaction/history.ts
+++ b/packages/indexer/src/transaction/history.ts
@@ -1,6 +1,6 @@
 import { connection } from "../connection";
 import { PublicKey } from "@solana/web3.js";
-import logger from "../logger";
+import { logger } from "../logger";
 
 export type TransactionMeta = Awaited<
   ReturnType<(typeof connection)["getSignaturesForAddress"]>
@@ -12,9 +12,9 @@ function throwInvariantViolation(
   before: string | undefined,
   violation: string
 ) {
-  logger.error(
-    `Invariant violated. account ${account.toBase58()}, after ${after}, before ${before}: ${violation}`
-  );
+  const error = new Error(`Invariant violated. account ${account.toBase58()}, after ${after}, before ${before}: ${violation}`);
+  logger.error(error.message);
+  throw error;
 }
 
 export async function getTransactionHistory(
@@ -83,7 +83,7 @@ export async function getTransactionHistory(
         `account contained before value of ${earliestSig}`
       );
     }
-    console.log(
+    logger.log(
       `page ${page} for ${account.toBase58()} (${history.length} total)`
     );
     page++;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@coral-xyz/anchor':
         specifier: ^0.28.1-beta.2
         version: 0.28.1-beta.2
+      '@lukasdeco/prom-client':
+        specifier: ^15.1.1
+        version: 15.1.1
       '@openbook-dex/openbook-v2':
         specifier: ^0.1.9
         version: 0.1.10
@@ -112,6 +115,9 @@ importers:
       commander:
         specifier: ^12.0.0
         version: 12.0.0
+      express:
+        specifier: ^4.19.2
+        version: 4.19.2
       inquirer:
         specifier: ^9.2.14
         version: 9.2.14
@@ -125,6 +131,9 @@ importers:
       '@types/bs58':
         specifier: ^4.0.1
         version: 4.0.4
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
       '@types/inquirer':
         specifier: ^9.0.7
         version: 9.0.7
@@ -522,6 +531,14 @@ packages:
     dependencies:
       call-bind: 1.0.6
 
+  /@lukasdeco/prom-client@15.1.1:
+    resolution: {integrity: sha512-qOdOtEL8dhrPkYwSUni6SxbR7s/h768e/LS4dFa5Ru0D2A2iqnY2GH7TnQD7xii8WpyLUxMJ8g9Tjs0LmJrhUg==}
+    engines: {node: ^16 || ^18 || >=20}
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      tdigest: 0.1.2
+    dev: false
+
   /@noble/curves@1.3.0:
     resolution: {integrity: sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==}
     dependencies:
@@ -565,6 +582,11 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: false
+
+  /@opentelemetry/api@1.8.0:
+    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
+    engines: {node: '>=8.0.0'}
     dev: false
 
   /@oven/bun-darwin-aarch64@1.0.26:
@@ -676,6 +698,13 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@types/body-parser@1.19.5:
+    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.11.16
+    dev: true
+
   /@types/bs58@4.0.4:
     resolution: {integrity: sha512-0IEpMFXXQi2zXaXl9GJ3sRwQo0uEkD+yFOv+FnAU5lkPtcu6h61xb7jc2CFPEZ5BUOaiP13ThuGc9HD4R8lR5g==}
     dependencies:
@@ -687,13 +716,42 @@ packages:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
       '@types/node': 20.11.16
-    dev: false
+
+  /@types/express-serve-static-core@4.17.43:
+    resolution: {integrity: sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==}
+    dependencies:
+      '@types/node': 20.11.16
+      '@types/qs': 6.9.14
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.4
+    dev: true
+
+  /@types/express@4.17.21:
+    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+    dependencies:
+      '@types/body-parser': 1.19.5
+      '@types/express-serve-static-core': 4.17.43
+      '@types/qs': 6.9.14
+      '@types/serve-static': 1.15.5
+    dev: true
+
+  /@types/http-errors@2.0.4:
+    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+    dev: true
 
   /@types/inquirer@9.0.7:
     resolution: {integrity: sha512-Q0zyBupO6NxGRZut/JdmqYKOnN95Eg5V8Csg3PGKkP+FnvsUZx1jAyK7fztIszxxMuoBA6E3KXWvdZVXIpx60g==}
     dependencies:
       '@types/through': 0.0.33
       rxjs: 7.8.1
+    dev: true
+
+  /@types/mime@1.3.5:
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+    dev: true
+
+  /@types/mime@3.0.4:
+    resolution: {integrity: sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==}
     dev: true
 
   /@types/node@12.20.55:
@@ -720,6 +778,14 @@ packages:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
     dev: true
 
+  /@types/qs@6.9.14:
+    resolution: {integrity: sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==}
+    dev: true
+
+  /@types/range-parser@1.2.7:
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+    dev: true
+
   /@types/react@18.2.55:
     resolution: {integrity: sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==}
     dependencies:
@@ -730,6 +796,21 @@ packages:
 
   /@types/scheduler@0.16.8:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
+    dev: true
+
+  /@types/send@0.17.4:
+    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 20.11.16
+    dev: true
+
+  /@types/serve-static@1.15.5:
+    resolution: {integrity: sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==}
+    dependencies:
+      '@types/http-errors': 2.0.4
+      '@types/mime': 3.0.4
+      '@types/node': 20.11.16
     dev: true
 
   /@types/through@0.0.33:
@@ -756,6 +837,14 @@ packages:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
+    dev: false
+
+  /accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
     dev: false
 
   /agentkeepalive@4.5.0:
@@ -807,6 +896,10 @@ packages:
 
   /ansicolor@2.0.1:
     resolution: {integrity: sha512-l9miLV3zQ+DRatsmo3vE4OCL5HntkEvaLU825teOrUHFCH+WZEwx3KV4EzfkhUGy90QWWdvhMj1NTzTK6yFbaQ==}
+
+  /array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    dev: false
 
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -861,6 +954,10 @@ packages:
       file-uri-to-path: 1.0.0
     dev: false
 
+  /bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+    dev: false
+
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -870,6 +967,26 @@ packages:
 
   /bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+    dev: false
+
+  /body-parser@1.20.2:
+    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /borsh@0.7.0:
@@ -962,6 +1079,11 @@ packages:
       '@oven/bun-linux-x64': 1.0.26
       '@oven/bun-linux-x64-baseline': 1.0.26
     dev: true
+
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /call-bind@1.0.6:
     resolution: {integrity: sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==}
@@ -1103,6 +1225,27 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
+  /content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: false
+
+  /cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
     dependencies:
@@ -1126,6 +1269,17 @@ packages:
       es5-ext: 0.10.62
       type: 1.2.0
     dev: true
+
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1161,6 +1315,16 @@ packages:
   /delay@5.0.0:
     resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
     engines: {node: '>=10'}
+    dev: false
+
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
     dev: false
 
   /difflib@0.2.4:
@@ -1280,12 +1444,21 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
@@ -1376,9 +1549,18 @@ packages:
       '@esbuild/win32-x64': 0.18.20
     dev: true
 
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
@@ -1394,6 +1576,45 @@ packages:
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: true
+
+  /express@4.19.2:
+    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.2
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.6.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -1452,6 +1673,21 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
+  /finalhandler@1.2.0:
+    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1469,6 +1705,16 @@ packages:
       debug:
         optional: true
     dev: true
+
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -1621,6 +1867,17 @@ packages:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
     dev: true
 
+  /http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+    dev: false
+
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
@@ -1670,6 +1927,11 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1846,6 +2108,11 @@ packages:
     resolution: {integrity: sha512-1P7vVC8pwb3NEIRdYz8YSq5Mdnjx/xMH/D8FAqKuDMMbuiGN4LQMtX8YcwUpd3mXRd6ORjnSnibrK/Iq+ObHZw==}
     dev: false
 
+  /media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /memoizee@0.4.15:
     resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==}
     dependencies:
@@ -1859,10 +2126,19 @@ packages:
       timers-ext: 0.1.7
     dev: true
 
+  /merge-descriptors@1.0.1:
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    dev: false
+
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
     dev: true
+
+  /methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -1871,6 +2147,24 @@ packages:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: true
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
+  /mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1907,8 +2201,16 @@ packages:
       minimist: 1.2.8
     dev: true
 
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
 
   /mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -1921,6 +2223,11 @@ packages:
     dependencies:
       undici: 5.28.3
     dev: true
+
+  /negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
@@ -1964,10 +2271,16 @@ packages:
 
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
-    dev: true
 
   /obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2033,6 +2346,11 @@ packages:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
     dev: false
 
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2042,6 +2360,10 @@ packages:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /path-to-regexp@0.1.7:
+    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2184,6 +2506,21 @@ packages:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
     dev: true
 
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
+  /qs@6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.5
+    dev: false
+
   /qs@6.11.2:
     resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
     engines: {node: '>=0.6'}
@@ -2194,6 +2531,21 @@ packages:
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -2300,6 +2652,39 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  /send@0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /serve-static@1.15.0:
+    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
@@ -2315,6 +2700,10 @@ packages:
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: false
+
   /side-channel@1.0.5:
     resolution: {integrity: sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==}
     engines: {node: '>= 0.4'}
@@ -2323,7 +2712,6 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
-    dev: true
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -2367,6 +2755,11 @@ packages:
   /split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+    dev: false
+
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /string-width@4.2.3:
@@ -2425,6 +2818,12 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
+  /tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+    dependencies:
+      bintrees: 1.0.2
+    dev: false
+
   /text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
     dev: false
@@ -2453,6 +2852,11 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
     dev: false
@@ -2472,6 +2876,14 @@ packages:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+    dev: false
 
   /type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
@@ -2503,6 +2915,11 @@ packages:
       normalize-path: 2.1.1
     dev: true
 
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /utf-8-validate@5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
     engines: {node: '>=6.14.2'}
@@ -2514,6 +2931,11 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  /utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
+
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -2523,6 +2945,11 @@ packages:
     resolution: {integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==}
     engines: {node: '>=12'}
     dev: true
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}


### PR DESCRIPTION
Adds a GET http endpoint with express(should we use something else? Fastify?) that exposes prometheus metrics. 
Added a logger class for incrementing error and warn metrics. So far we just have errors it seems to log and increment.

Notes:
Had to used a forked version of prom-client. I'll open a PR with my fork and then when they merge it in(hopefully) we can go back to using the real library.

There are tons of formatting changes from my prettier... maybe if we all use same formatter we can agree on print width and tabs and all that.