### PR TITLE
feat: populate jupe does not index price

### DIFF
--- a/packages/indexer/src/cli/txw/populate.ts
+++ b/packages/indexer/src/cli/txw/populate.ts
@@ -23,7 +23,7 @@ import { connection, readonlyWallet } from "../../connection";
 import { Err, Ok } from "../../match";
 import {
   JupiterQuoteIndexingError,
-  JupiterQuotesIndexer,
+  fetchQuoteFromJupe,
 } from "../../indexers/jupiter/jupiter-quotes-indexer";
 
 import Cron from "croner";
@@ -211,12 +211,9 @@ async function populateJupQuoteIndexerAndMarket(token: {
   const { mintAcct } = token;
   try {
     //check to see if jupiter can support this token
-    const res = await JupiterQuotesIndexer.index(mintAcct);
-    if (
-      !res.success &&
-      res.error.type === JupiterQuoteIndexingError.JupiterFetchError
-    ) {
-      return Err({ type: PopulateSpotPriceMarketErrors.NotSupportedByJup });
+    const number = await fetchQuoteFromJupe(mintAcct);
+    if (!number) {
+      return Err({ type: JupiterQuoteIndexingError.JupiterFetchError });
     }
 
     // it is supported, so let's continue on

--- a/packages/indexer/src/indexers/jupiter/jupiter-quotes-indexer.ts
+++ b/packages/indexer/src/indexers/jupiter/jupiter-quotes-indexer.ts
@@ -16,70 +16,19 @@ export const JupiterQuotesIndexer: IntervalFetchIndexer = {
   index: async (acct: string) => {
     // get decimals from our DB
     try {
-      const inputToken = await usingDb((db) =>
-        db
-          .select()
-          .from(schema.tokens)
-          .where(eq(schema.tokens.mintAcct, acct))
-          .execute()
-      );
-      // call jup
-
-      // if it's USDC we compare to USDT
-      const outputMint =
-        acct === "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-          ? "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
-          : "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
-
-      const outputToken = await usingDb((db) =>
-        db
-          .select()
-          .from(schema.tokens)
-          .where(eq(schema.tokens.mintAcct, outputMint))
-          .execute()
-      );
-
-      const url =
-        `https://quote-api.jup.ag/v6/quote?inputMint=${acct}&` +
-        `outputMint=${outputMint}&` +
-        `amount=${(100_000).toString()}&` +
-        "slippageBps=50&" +
-        "swapMode=ExactIn&" +
-        "onlyDirectRoutes=false&" +
-        "maxAccounts=64&" +
-        "experimentalDexes=Jupiter%20LO";
-      const tokenPriceRes = await fetch(url);
-
-      if (tokenPriceRes.status !== 200) {
-        console.error(
-          "non-200 response from jupiter quotes:",
-          tokenPriceRes.status,
-          tokenPriceRes.statusText
-        );
-      }
-
-      const tokenPriceJson = (await tokenPriceRes.json()) as JupTokenQuoteRes;
-
-      if (tokenPriceJson.error) {
-        return Err({ type: JupiterQuoteIndexingError.JupiterFetchError });
-      }
-
-      if (!tokenPriceJson.outAmount || !tokenPriceJson.inAmount) {
-        console.error("token price output or input is 0 value");
+      const fetchQuoteRes = await fetchQuoteFromJupe(acct);
+      if (!fetchQuoteRes) {
         return Err({
-          type: JupiterQuoteIndexingError.GeneralJupiterQuoteIndexError,
+          type: JupiterQuoteIndexingError.JupiterFetchError,
         });
       }
+      const [price, slot] = fetchQuoteRes;
       const newPrice: PricesRecord = {
         marketAcct: acct,
-        price: convertJupTokenPrice(
-          tokenPriceJson,
-          inputToken[0].decimals,
-          outputToken[0].decimals
-        ).toString(),
+        price: price.toString(),
         pricesType: PricesType.Spot,
         createdBy: "jupiter-quotes-indexer",
-        updatedSlot: BigInt(tokenPriceJson.contextSlot ?? 0),
+        updatedSlot: BigInt(slot ?? 0),
       };
 
       const insertPriceRes = await usingDb((db) =>
@@ -119,4 +68,74 @@ const convertJupTokenPrice = (
     10 ** outputTokenDecimals /
     (Number(data.inAmount ?? "0") / 10 ** inputTokenDecimals);
   return price;
+};
+
+export const fetchQuoteFromJupe = async (
+  acct: string
+): Promise<[number, number | undefined] | null> => {
+  try {
+    const inputToken = await usingDb((db) =>
+      db
+        .select()
+        .from(schema.tokens)
+        .where(eq(schema.tokens.mintAcct, acct))
+        .execute()
+    );
+    // call jup
+
+    // if it's USDC we compare to USDT
+    const outputMint =
+      acct === "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        ? "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+        : "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    const outputToken = await usingDb((db) =>
+      db
+        .select()
+        .from(schema.tokens)
+        .where(eq(schema.tokens.mintAcct, outputMint))
+        .execute()
+    );
+
+    const url =
+      `https://quote-api.jup.ag/v6/quote?inputMint=${acct}&` +
+      `outputMint=${outputMint}&` +
+      `amount=${(100_000).toString()}&` +
+      "slippageBps=50&" +
+      "swapMode=ExactIn&" +
+      "onlyDirectRoutes=false&" +
+      "maxAccounts=64&" +
+      "experimentalDexes=Jupiter%20LO";
+    const tokenPriceRes = await fetch(url);
+
+    if (tokenPriceRes.status !== 200) {
+      console.error(
+        "non-200 response from jupiter quotes:",
+        tokenPriceRes.status,
+        tokenPriceRes.statusText
+      );
+    }
+
+    const tokenPriceJson = (await tokenPriceRes.json()) as JupTokenQuoteRes;
+
+    if (tokenPriceJson.error) {
+      return null;
+    }
+
+    if (!tokenPriceJson.outAmount || !tokenPriceJson.inAmount) {
+      console.error("token price output or input is 0 value");
+      return null;
+    }
+    return [
+      convertJupTokenPrice(
+        tokenPriceJson,
+        inputToken[0].decimals,
+        outputToken[0].decimals
+      ),
+      tokenPriceJson.contextSlot,
+    ];
+  } catch (e) {
+    console.error("error getting price number from jupiter: ", e);
+    return null;
+  }
 };


### PR DESCRIPTION
We want to be able to disable jupe price indexing for some coins (META) and only use birdeye for seeminlgy smoother prices. However, when the populate indexers function runs, currently it actually creates a price record for every base token that returns a successful response from jup. This is because the way the code was written to test if a token can be indexed on jupiter or birdeye. This PR changes that so we only check to see if the price can be fetched from jupiter, not actually indexing the price as well.
