### PR TITLE
export type, store slot as string

### DIFF
--- a/packages/database/lib/drizzle.config.ts
+++ b/packages/database/lib/drizzle.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "drizzle-kit";
 export default defineConfig({
+  dialect: "postgresql",
   verbose: true,
 });

--- a/packages/database/lib/index.ts
+++ b/packages/database/lib/index.ts
@@ -136,3 +136,5 @@ export {
   isNull,
   inArray,
 } from "drizzle-orm";
+
+export type DBConnection = NodePgDatabase<typeof schemaDefs>;

--- a/packages/database/lib/schema.ts
+++ b/packages/database/lib/schema.ts
@@ -1,4 +1,4 @@
-import { SQL, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import {
   bigint,
   doublePrecision,

--- a/packages/database/lib/schema.ts
+++ b/packages/database/lib/schema.ts
@@ -651,7 +651,8 @@ export const comments = pgTable("comments", {
   // it references only commentIds which have respondingCommentId with NULL
   respondingCommentId: bigint("responding_comment_id", {
     mode: "bigint",
-  }).references(() => comments.commentId),
+    // for circular references we need to cast to any
+  }).references((): any => comments.commentId),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .default(sql`now()`),

--- a/packages/database/src/run-sql.ts
+++ b/packages/database/src/run-sql.ts
@@ -27,7 +27,7 @@ async function main() {
   const statement = arg ?? await chooseCommonStatement();
   console.log(green(statement));
   const result = await usingDb(db => db.execute(sql.raw(statement)));
-  if (result.rowCount) {
+  if (result?.rowCount) {
     console.log('total:', result.rowCount);
     console.log(table(result.rows));
     return;

--- a/packages/indexer/src/v3_indexer/transaction/serializer.ts
+++ b/packages/indexer/src/v3_indexer/transaction/serializer.ts
@@ -256,7 +256,7 @@ async function parseInstructions(
     const outerIxWithDisplay = getIxWithDisplay(
       {
         ...curOuter,
-        data: Buffer.from(curOuter.data),
+        data: Buffer.from(curOuter.data.buffer),
         accounts: curOuter.accountKeyIndexes,
       },
       idl,
@@ -305,7 +305,7 @@ async function parseInstructions(
       const innerIxWithDisplay = getIxWithDisplay(
         {
           ...curOuter,
-          data: Buffer.from(curOuter.data),
+          data: Buffer.from(curOuter.data.buffer),
           accounts: curOuter.accountKeyIndexes,
         },
         idl,
@@ -397,7 +397,7 @@ function getIxWithDisplay(
   }
 
   try {
-    decodedIx = coder.decode(Buffer.from(instruction.data));
+    decodedIx = coder.decode(Buffer.from(instruction.data.buffer));
   } catch (e) {
     logger.error("error with coder decoding of instruction:", e);
     return null;

--- a/packages/indexer/src/v4_indexer/indexer.ts
+++ b/packages/indexer/src/v4_indexer/indexer.ts
@@ -1,4 +1,4 @@
-import { AMM_PROGRAM_ID, CONDITIONAL_VAULT_PROGRAM_ID } from "@metadaoproject/futarchy/v0.4";
+import { AMM_PROGRAM_ID, CONDITIONAL_VAULT_PROGRAM_ID, ConditionalVaultEvent } from "@metadaoproject/futarchy/v0.4";
 import * as anchor from "@coral-xyz/anchor";
 import { CompiledInnerInstruction, PublicKey, TransactionResponse, VersionedTransactionResponse } from "@solana/web3.js";
 
@@ -14,9 +14,9 @@ import { processAmmEvent, processVaultEvent } from "./processor";
 
 const logger = new Logger(new TelegramBotAPI({token: process.env.TELEGRAM_BOT_API_KEY ?? ''}));
 
-const parseEvents = (transactionResponse: VersionedTransactionResponse | TransactionResponse): { ammEvents: any, vaultEvents: any } => {
-  const ammEvents: { name: string; data: any }[] = [];
-  const vaultEvents: { name: string; data: any }[] = [];
+const parseEvents = (transactionResponse: VersionedTransactionResponse | TransactionResponse): { ammEvents: {name: string; data: ConditionalVaultEvent}[], vaultEvents: {name: string; data: ConditionalVaultEvent}[] } => {
+  const ammEvents: { name: string; data: ConditionalVaultEvent }[] = [];
+  const vaultEvents: { name: string; data: ConditionalVaultEvent }[] = [];
   try {
     const inner: CompiledInnerInstruction[] =
       transactionResponse?.meta?.innerInstructions ?? [];
@@ -45,7 +45,7 @@ const parseEvents = (transactionResponse: VersionedTransactionResponse | Transac
           const eventData = anchor.utils.bytes.base64.encode(ixData.slice(8));
           const event = program.coder.events.decode(eventData);
           if (event) {
-            ammEvents.push(event);
+            ammEvents.push({name: event.name, data: event.data as ConditionalVaultEvent});
           }
         } else if (programPubkey.equals(vaultIdlProgramId)) {
           program = conditionalVaultClient.vaultProgram;
@@ -55,7 +55,7 @@ const parseEvents = (transactionResponse: VersionedTransactionResponse | Transac
           const eventData = anchor.utils.bytes.base64.encode(ixData.slice(8));
           const event = program.coder.events.decode(eventData);
           if (event) {
-            vaultEvents.push(event);
+            vaultEvents.push({name: event.name, data: event.data as ConditionalVaultEvent});
           }
         }
       }
@@ -109,14 +109,14 @@ export async function index(signature: string, programId: PublicKey) {
     });
 
     const events = parseEvents(transactionResponse);
-    const ammEvents = events.ammEvents;
-    const vaultEvents = events.vaultEvents;
+    const ammEvents: {name: string; data: ConditionalVaultEvent}[] = events.ammEvents;
+    const vaultEvents: {name: string; data: ConditionalVaultEvent}[] = events.vaultEvents;
 
-    Promise.all(ammEvents.map(async (event: {name: string; data: any}) => {
+    Promise.all(ammEvents.map(async (event: {name: string; data: ConditionalVaultEvent}) => {
       await processAmmEvent(event, signature, transactionResponse);
     }));
 
-    Promise.all(vaultEvents.map(async (event: {name: string; data: any}) => {
+    Promise.all(vaultEvents.map(async (event: {name: string; data: ConditionalVaultEvent}) => {
       await processVaultEvent(event, signature, transactionResponse);
     }));
     

--- a/packages/indexer/src/v4_indexer/indexer.ts
+++ b/packages/indexer/src/v4_indexer/indexer.ts
@@ -2,7 +2,7 @@ import { AMM_PROGRAM_ID, CONDITIONAL_VAULT_PROGRAM_ID } from "@metadaoproject/fu
 import * as anchor from "@coral-xyz/anchor";
 import { CompiledInnerInstruction, PublicKey, TransactionResponse, VersionedTransactionResponse } from "@solana/web3.js";
 
-import { schema, usingDb } from "@metadaoproject/indexer-db";
+import { DBConnection, schema, usingDb } from "@metadaoproject/indexer-db";
 import { v4AmmClient as ammClient, v4ConditionalVaultClient as conditionalVaultClient } from "../connection";
 import { Program } from "@coral-xyz/anchor";
 import { Context, Logs } from "@solana/web3.js";
@@ -13,7 +13,6 @@ import { rpc } from "../rpc-wrapper";
 import { processAmmEvent, processVaultEvent } from "./processor";
 
 const logger = new Logger(new TelegramBotAPI({token: process.env.TELEGRAM_BOT_API_KEY ?? ''}));
-type DBConnection = any; // TODO: Fix typing..
 
 const parseEvents = (transactionResponse: VersionedTransactionResponse | TransactionResponse): { ammEvents: any, vaultEvents: any } => {
   const ammEvents: { name: string; data: any }[] = [];
@@ -98,7 +97,7 @@ export async function index(signature: string, programId: PublicKey) {
     await usingDb(async (db: DBConnection) => {
       await db.insert(schema.signatures).values({
         signature: transactionResponse.transaction.signatures[0],
-        slot: BigInt(transactionResponse.slot),
+        slot: transactionResponse.slot.toString(),
         didErr: transactionResponse.meta?.err !== null,
         err: transactionResponse.meta?.err ? JSON.stringify(transactionResponse.meta.err) : null,
         blockTime: transactionResponse.blockTime ? new Date(transactionResponse.blockTime * 1000) : null,
@@ -113,11 +112,11 @@ export async function index(signature: string, programId: PublicKey) {
     const ammEvents = events.ammEvents;
     const vaultEvents = events.vaultEvents;
 
-    Promise.all(ammEvents.map(async (event) => {
+    Promise.all(ammEvents.map(async (event: {name: string; data: any}) => {
       await processAmmEvent(event, signature, transactionResponse);
     }));
 
-    Promise.all(vaultEvents.map(async (event) => {
+    Promise.all(vaultEvents.map(async (event: {name: string; data: any}) => {
       await processVaultEvent(event, signature, transactionResponse);
     }));
     

--- a/packages/indexer/src/v4_indexer/indexer.ts
+++ b/packages/indexer/src/v4_indexer/indexer.ts
@@ -2,7 +2,7 @@ import { AMM_PROGRAM_ID, CONDITIONAL_VAULT_PROGRAM_ID, ConditionalVaultEvent } f
 import * as anchor from "@coral-xyz/anchor";
 import { CompiledInnerInstruction, PublicKey, TransactionResponse, VersionedTransactionResponse } from "@solana/web3.js";
 
-import { DBConnection, schema, usingDb } from "@metadaoproject/indexer-db";
+import { schema, usingDb } from "@metadaoproject/indexer-db";
 import { v4AmmClient as ammClient, v4ConditionalVaultClient as conditionalVaultClient } from "../connection";
 import { Program } from "@coral-xyz/anchor";
 import { Context, Logs } from "@solana/web3.js";
@@ -94,7 +94,7 @@ export async function index(signature: string, programId: PublicKey) {
     }
 
     //insert signature to db
-    await usingDb(async (db: DBConnection) => {
+    await usingDb(async (db) => {
       await db.insert(schema.signatures).values({
         signature: transactionResponse.transaction.signatures[0],
         slot: transactionResponse.slot.toString(),
@@ -109,14 +109,14 @@ export async function index(signature: string, programId: PublicKey) {
     });
 
     const events = parseEvents(transactionResponse);
-    const ammEvents: {name: string; data: ConditionalVaultEvent}[] = events.ammEvents;
-    const vaultEvents: {name: string; data: ConditionalVaultEvent}[] = events.vaultEvents;
+    const ammEvents = events.ammEvents;
+    const vaultEvents = events.vaultEvents;
 
-    Promise.all(ammEvents.map(async (event: {name: string; data: ConditionalVaultEvent}) => {
+    Promise.all(ammEvents.map(async (event) => {
       await processAmmEvent(event, signature, transactionResponse);
     }));
 
-    Promise.all(vaultEvents.map(async (event: {name: string; data: ConditionalVaultEvent}) => {
+    Promise.all(vaultEvents.map(async (event) => {
       await processVaultEvent(event, signature, transactionResponse);
     }));
     

--- a/packages/indexer/src/v4_indexer/processor.ts
+++ b/packages/indexer/src/v4_indexer/processor.ts
@@ -11,9 +11,9 @@ import { AddLiquidityEvent,
   SplitTokensEvent,
   MergeTokensEvent,
   RemoveLiquidityEvent } from "@metadaoproject/futarchy/v0.4";
-import { schema, usingDb, eq, and, or } from "@metadaoproject/indexer-db";
+import { schema, usingDb, eq, and, or, DBConnection } from "@metadaoproject/indexer-db";
 import { PublicKey, VersionedTransactionResponse } from "@solana/web3.js";
-import { PricesType, V04SwapType } from "@metadaoproject/indexer-db/lib/schema";
+import { MarketType, PricesType, V04SwapType } from "@metadaoproject/indexer-db/lib/schema";
 import * as token from "@solana/spl-token";
 
 import { connection, v4ConditionalVaultClient as conditionalVaultClient } from "../connection";
@@ -28,8 +28,6 @@ type Market = {
   baseMint: string;
   quoteMint: string;
 }
-
-type DBConnection = any; // TODO: Fix typing..
 
 
 export async function processAmmEvent(event: { name: string; data: AmmEvent }, signature: string, transactionResponse: VersionedTransactionResponse) {
@@ -62,11 +60,10 @@ async function handleCreateAmmEvent(event: CreateAmmEvent) {
         baseMint: event.baseMint.toString(),
         quoteMint: event.quoteMint.toString(),
       });
-
       await db.insert(schema.v0_4_amms).values({
         ammAddr: event.common.amm.toString(),
         lpMintAddr: event.lpMint.toString(),
-        createdAtSlot: BigInt(event.common.slot.toString()),
+        createdAtSlot: event.common.slot.toString(),
         baseMintAddr: event.baseMint.toString(),
         quoteMintAddr: event.quoteMint.toString(),
         latestAmmSeqNumApplied: 0n,
@@ -93,7 +90,7 @@ async function handleAddLiquidityEvent(event: AddLiquidityEvent) {
         return;
       }
 
-      if (amm[0].latestAmmSeqNumApplied >= BigInt(event.common.seqNum.toString())) {
+      if (amm[0].latestAmmSeqNumApplied >= event.common.seqNum.toString()) {
         console.log("Already applied", event.common.seqNum.toString());
         return;
       }
@@ -101,9 +98,9 @@ async function handleAddLiquidityEvent(event: AddLiquidityEvent) {
       await insertPriceIfNotDuplicate(db, amm, event);
 
       await db.update(schema.v0_4_amms).set({
-        baseReserves: BigInt(event.common.postBaseReserves.toString()),
-        quoteReserves: BigInt(event.common.postQuoteReserves.toString()),
-        latestAmmSeqNumApplied: BigInt(event.common.seqNum.toString()),
+        baseReserves: event.common.postBaseReserves.toString(),
+        quoteReserves: event.common.postQuoteReserves.toString(),
+        latestAmmSeqNumApplied: event.common.seqNum.toString(),
       }).where(eq(schema.v0_4_amms.ammAddr, event.common.amm.toString()));
 
       console.log("Updated AMM", event.common.amm.toString());
@@ -127,7 +124,7 @@ async function handleRemoveLiquidityEvent(event: RemoveLiquidityEvent) {
         return;
       }
 
-      if (amm[0].latestAmmSeqNumApplied >= BigInt(event.common.seqNum.toString())) {
+      if (amm[0].latestAmmSeqNumApplied >= event.common.seqNum.toString()) {
         console.log("Already applied", event.common.seqNum.toString());
         return;
       }
@@ -135,9 +132,9 @@ async function handleRemoveLiquidityEvent(event: RemoveLiquidityEvent) {
       await insertPriceIfNotDuplicate(db, amm, event);
 
       await db.update(schema.v0_4_amms).set({
-        baseReserves: BigInt(event.common.postBaseReserves.toString()),
-        quoteReserves: BigInt(event.common.postQuoteReserves.toString()),
-        latestAmmSeqNumApplied: BigInt(event.common.seqNum.toString()),
+        baseReserves: event.common.postBaseReserves.toString(),
+        quoteReserves: event.common.postQuoteReserves.toString(),
+        latestAmmSeqNumApplied: event.common.seqNum.toString(),
       }).where(eq(schema.v0_4_amms.ammAddr, event.common.amm.toString()));
 
       console.log("Updated AMM", event.common.amm.toString());
@@ -159,15 +156,14 @@ async function handleSwapEvent(event: SwapEvent, signature: string, transactionR
     await usingDb(async (db: DBConnection) => {
       await db.insert(schema.v0_4_swaps).values({
         signature: signature,
-        slot: BigInt(transactionResponse.slot),
-        // @ts-ignore - fixed above in the if statement
-        blockTime: new Date(transactionResponse.blockTime * 1000),
+        slot: transactionResponse.slot.toString(),
+        blockTime: new Date((transactionResponse.blockTime ?? 0) * 1000),
         swapType: event.swapType.buy ? V04SwapType.Buy : V04SwapType.Sell,
         ammAddr: event.common.amm.toString(),
         userAddr: event.common.user.toString(),
         inputAmount: event.inputAmount.toString(),
         outputAmount: event.outputAmount.toString(),
-        ammSeqNum: BigInt(event.common.seqNum.toString())
+        ammSeqNum: event.common.seqNum.toString()
       }).onConflictDoNothing();
 
       const amm = await db.select().from(schema.v0_4_amms).where(eq(schema.v0_4_amms.ammAddr, event.common.amm.toString())).limit(1);
@@ -179,7 +175,7 @@ async function handleSwapEvent(event: SwapEvent, signature: string, transactionR
 
       console.log("latestAmmSeqNumApplied", amm[0].latestAmmSeqNumApplied.toString());
       console.log("event.common.seqNum", event.common.seqNum.toString());
-      if (amm[0].latestAmmSeqNumApplied >= BigInt(event.common.seqNum.toString())) {
+      if (amm[0].latestAmmSeqNumApplied >= event.common.seqNum.toString()) {
         console.log("Already applied", event.common.seqNum.toString());
         return;
       }
@@ -187,9 +183,9 @@ async function handleSwapEvent(event: SwapEvent, signature: string, transactionR
       await insertPriceIfNotDuplicate(db, amm, event);
 
       await db.update(schema.v0_4_amms).set({
-        baseReserves: BigInt(event.common.postBaseReserves.toString()),
-        quoteReserves: BigInt(event.common.postQuoteReserves.toString()),
-        latestAmmSeqNumApplied: BigInt(event.common.seqNum.toString()),
+        baseReserves: event.common.postBaseReserves.toString(),
+        quoteReserves: event.common.postQuoteReserves.toString(),
+        latestAmmSeqNumApplied: event.common.seqNum.toString(),
       }).where(eq(schema.v0_4_amms.ammAddr, event.common.amm.toString()));
     });
   } catch (error) {
@@ -205,10 +201,10 @@ async function handleSplitEvent(event: SplitTokensEvent, signature: string, tran
   try {
     const insertValues = {
       vaultAddr: event.vault.toString(),
-      vaultSeqNum: BigInt(event.seqNum.toString()),
+      vaultSeqNum: event.seqNum.toString(),
       signature: signature,
-      slot: BigInt(transactionResponse.slot),
-      amount: BigInt(event.amount.toString())
+      slot: transactionResponse.slot.toString(),
+      amount: event.amount.toString()
       // Note: createdAt will be set automatically by the default value
     };
     
@@ -246,10 +242,10 @@ async function handleMergeEvent(event: MergeTokensEvent, signature: string, tran
     await usingDb(async (db: DBConnection) => {
       await db.insert(schema.v0_4_merges).values({
         vaultAddr: event.vault.toString(),
-        vaultSeqNum: BigInt(event.seqNum.toString()),
+        vaultSeqNum: event.seqNum.toString(),
         signature: signature,
-        slot: BigInt(transactionResponse.slot),
-        amount: BigInt(event.amount.toString())
+        slot: transactionResponse.slot.toString(),
+        amount: event.amount.toString()
       }).onConflictDoNothing();
     });
   } catch (error) {
@@ -271,7 +267,7 @@ async function insertTokenIfNotExists(db: DBConnection, mintAcct: PublicKey) {
       symbol: mintAcct.toString().slice(0, 3),
       name: mintAcct.toString().slice(0, 3),
       decimals: mint.decimals,
-      supply: mint.supply,
+      supply: mint.supply.toString(),
       updatedAt: new Date(),
     }).onConflictDoNothing();
   }
@@ -403,7 +399,7 @@ async function insertTokenAccountIfNotExists(db: DBConnection, event: Initialize
       tokenAcct: event.vaultUnderlyingTokenAccount.toString(),
       mintAcct: event.underlyingTokenMint.toString(),
       ownerAcct: event.vaultUnderlyingTokenAccount.toString(),
-      amount: 0n,
+      amount: 0n.toString(),
     });
   }
 }
@@ -419,11 +415,11 @@ async function insertMarketIfNotExists(db: DBConnection, market: Market) {
       marketAcct: market.marketAcct,
       baseMintAcct: market.baseMint,
       quoteMintAcct: market.quoteMint,
-      marketType: 'amm',
+      marketType: MarketType.FUTARCHY_AMM,
       createTxSig: '',
-      baseLotSize: 0n,
-      quoteLotSize: 0n,
-      quoteTickSize: 0n,
+      baseLotSize: 0n.toString(),
+      quoteLotSize: 0n.toString(),
+      quoteTickSize: 0n.toString(),
       baseMakerFee: 0,
       quoteMakerFee: 0,
       baseTakerFee: 0,
@@ -431,8 +427,9 @@ async function insertMarketIfNotExists(db: DBConnection, market: Market) {
     }).onConflictDoNothing();
   }
 }
+type AmmInsertion = typeof schema.v0_4_amms.$inferInsert;
 
-async function insertPriceIfNotDuplicate(db: DBConnection, amm: any[], event: AddLiquidityEvent | SwapEvent | RemoveLiquidityEvent) {
+async function insertPriceIfNotDuplicate(db: DBConnection, amm: AmmInsertion[], event: AddLiquidityEvent | SwapEvent | RemoveLiquidityEvent) {
   console.log("insertPriceIfNotDuplicate::event", event);
   const existingPrice = await db.select()
     .from(schema.prices)
@@ -465,10 +462,10 @@ async function insertPriceIfNotDuplicate(db: DBConnection, amm: any[], event: Ad
 
   await db.insert(schema.prices).values({
     marketAcct: event.common.amm.toBase58(),
-    baseAmount: BigInt(event.common.postBaseReserves.toString()),
-    quoteAmount: BigInt(event.common.postQuoteReserves.toString()),
+    baseAmount: event.common.postBaseReserves.toString(),
+    quoteAmount: event.common.postQuoteReserves.toString(),
     price: humanPrice.toString(),
-    updatedSlot: BigInt(event.common.slot.toString()),
+    updatedSlot: event.common.slot.toString(),
     createdBy: 'amm-market-indexer',
     pricesType: PricesType.Conditional,
   }).onConflictDoNothing();


### PR DESCRIPTION
hi!

I was told about this and think its a great project, might also use this myself.
browsing the code I found two pretty simple things:
- we never export the db connection type and use any, whereas we really have it
- we convert slot to bigint. the table col is numeric, pretty sure it expects a string. `.toString()` should work for both, numbers and bigints, so we could even upgrade to web3.js 2.0 bigints (if they are even being returned here)

Right now I just wanted to fix the type errors. If you prefer strings over bigints or the other way round, let me know and I can set it straight everywhere.

regards
0xAlice

EDIT: I did some more typescript stuff. we're handling bigint differently, I think to be consistent we either have to use strings everywhere or change the schema have the option `{mode: "bigint"}` everywhere.
